### PR TITLE
Add a license file and only ship the necessary libs in the gem artifact

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2010-2011 Michael Jackson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+The software is provided "as is", without warranty of any kind, express or
+implied, including but not limited to the warranties of merchantability,
+fitness for a particular purpose and non-infringement. In no event shall the
+authors or copyright holders be liable for any claim, damages or other
+liability, whether in an action of contract, tort or otherwise, arising from,
+out of or in connection with the software or the use or other dealings in
+the software.

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ evaluate a raw string of grammar code), the return value is an array of all the
 grammars present in that file.
 
 Take a look at
-[calc.citrus](http://github.com/mjackson/citrus/blob/master/lib/citrus/grammars/calc.citrus)
+[calc.citrus](https://github.com/mjackson/citrus/blob/master/lib/citrus/grammars/calc.citrus)
 for an example of a calculator that is able to parse and evaluate more complex
 mathematical expressions.
 

--- a/citrus.gemspec
+++ b/citrus.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.rdoc_options = %w< --line-numbers --inline-source --title Citrus --main Citrus >
   s.extra_rdoc_files = %w< README.md CHANGES >
 
-  s.homepage = 'http://mjackson.github.io/citrus'
+  s.homepage = 'https://mjackson.github.io/citrus'
   s.licenses = ['MIT']
 end

--- a/citrus.gemspec
+++ b/citrus.gemspec
@@ -15,12 +15,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = %w< lib >
 
-  s.files = Dir['benchmark/**'] +
-    Dir['doc/**'] +
-    Dir['extras/**'] +
-    Dir['lib/**/*.rb'] +
-    Dir['test/**/*'] +
-    %w< citrus.gemspec Rakefile README.md CHANGES >
+  s.files =  Dir['lib/**/*.rb'] << "README.md"
 
   s.test_files = s.files.select {|path| path =~ /^test\/.*_test.rb/ }
 

--- a/citrus.gemspec
+++ b/citrus.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
 
-  s.has_rdoc = true
   s.rdoc_options = %w< --line-numbers --inline-source --title Citrus --main Citrus >
   s.extra_rdoc_files = %w< README.md CHANGES >
 


### PR DESCRIPTION
A lot of 3rd party apps (and GitHub) parse out license files in project repos. This makes that possible now.

The gemspec changes strips the gem artifact down to just the necessary files to use the library. The full set of development files aren't needed in a gem artifact and they just make Ruby installs larger and apps that use this library larger.