### PR TITLE
add options to Match#parse

### DIFF
--- a/test/grammar_test.rb
+++ b/test/grammar_test.rb
@@ -161,4 +161,28 @@ class GrammarTest < Test::Unit::TestCase
       grammar(:abc)
     end
   end
+
+  def test_options
+    grammer = Grammar.new {
+      rule(:number) { ext(/[0-9]+/) { @options } }
+    }
+    match = grammer.parse('1234', {test1: true, test2: "abc"})
+    options = match.value
+
+    assert_equal(true, options[:test1])
+    assert_equal('abc', options[:test2])
+  end
+
+  def test_optioin_upcase
+    grammer = Grammar.new {
+      rule(:alpha) do
+        ext(/[a-z]+/) { @options[:upcast] ? to_s.upcase : to_s }
+      end
+    }
+    match = grammer.parse('abc')
+    assert_equal('abc', match.value)
+
+    match = grammer.parse('abc', { upcast: true })
+    assert_equal('ABC', match.value)
+  end
 end


### PR DESCRIPTION
Please add options argument to Match#parse in order to improve the flexibility of Match#value.

I think the user will be able to choose to symbolize the key or capitalize the string or something.