### PR TITLE
work around Array#slice! bug

### DIFF
--- a/lib/citrus.rb
+++ b/lib/citrus.rb
@@ -1156,7 +1156,7 @@ module Citrus
         events << CLOSE
         events << length
       else
-        events.slice!(start, index)
+        events.slice!(start..index)
       end
 
       events
@@ -1213,7 +1213,7 @@ module Citrus
         events << CLOSE
         events << length
       else
-        events.slice!(start, index)
+        events.slice!(start..index)
       end
 
       events
@@ -1283,7 +1283,7 @@ module Citrus
 
         while events[0].elide?
           elisions.unshift(events.shift)
-          events.slice!(-2, events.length)
+          events.slice!(-2..events.length)
         end
 
         events[0].extend_match(self)


### PR DESCRIPTION
In a few places, the end of an events array is sliced using `Array#slice!` passing the initial element (or offset from the end) followed by a second parameter which is the length of the array.

The documentation for Array#slice! tells us that the second argument should be the _length_ of the slice, and not the _end index_ of the slice; but normally Ruby will cap the length of the slice to the number of elements left in the array.

However, there's a bug in Ruby 3.0.0--3.0.2 (https://bugs.ruby-lang.org/issues/18138) that skips the sanity check on length and causes illegal memory access and occasional segfaults. This change fixes the arguments to use a Range object whose end is used as the final index of the slice as I believe the author originally intended, and prevent triggering this bug in Array#slice!

Fixes #60